### PR TITLE
Fix Docker build and Maven build warnings.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,6 @@ ENV SENZING_G2_DIR=${SENZING_ROOT}/g2
 ENV PYTHONPATH=${SENZING_ROOT}/g2/python
 ENV LD_LIBRARY_PATH=${SENZING_ROOT}/g2/lib:${SENZING_ROOT}/g2/lib/debian
 
-# Build "senzing-listener.jar".
-
-COPY senzing-listener /senzing-listener
-WORKDIR /senzing-listener
-RUN mvn install
-
 # Build "risk-scoring-calculator.jar".
 
 COPY . /risk-scoring-calculator

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
       <version>1.4</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
+      <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.2</version>
     </dependency>


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #52

## Why was change needed

Docker builds failing

## What does change improve
The Build pulled in sensing-listener and attempted to build it and this gave an error.  The listener has been put into its own repository and pulled in during the risk-score-calculator build and not built separately.
Also fixes a warning during Maven build.